### PR TITLE
Do not require jre directory to be prefixed with 'jre'

### DIFF
--- a/installer/src/main/java/com/github/dcevm/installer/ConfigurationInfo.java
+++ b/installer/src/main/java/com/github/dcevm/installer/ConfigurationInfo.java
@@ -161,7 +161,7 @@ public enum ConfigurationInfo {
 
     // Utility methods to query installation directories
     public boolean isJRE(Path directory) {
-        if (Files.isDirectory(directory) && directory.getFileName().toString().startsWith("jre")) {
+        if (Files.isDirectory(directory)) {
             if (!Files.exists(directory.resolve(getJavaExecutable()))) {
                 return false;
             }


### PR DESCRIPTION
In case of some custom installation, e.g. i have special dcevm-enabled jre at `/opt/oracle-jre-bin-1.8.0.45-dcevm/`